### PR TITLE
Fixes bug in slice combined with infinite iterator

### DIFF
--- a/src/Zicht/Itertools/lib/SliceIterator.php
+++ b/src/Zicht/Itertools/lib/SliceIterator.php
@@ -62,18 +62,32 @@ class SliceIterator extends \IteratorIterator implements \ArrayAccess, \Countabl
 
     public function __construct(\Iterator $iterable, $start, $end = null)
     {
+        if ($start < 0 || $end < 0) {
+            $length = iterator_count($iterable);
+        }
+
         $this->index = 0;
-        $this->start = $start < 0 ? iterator_count($iterable) + $start: $start;
-        $this->end = $end === null ? null : ($end < 0 ? iterator_count($iterable) + $end : $end);
+        $this->start = $start < 0 ? $length + $start: $start;
+        $this->end = $end === null ? null : ($end < 0 ? $length + $end : $end);
         parent::__construct($iterable);
     }
 
     public function valid()
     {
-        while (parent::valid() && !($this->start <= $this->index && (null === $this->end || $this->index < $this->end))) {
-            $this->next();
+        while ($this->index < $this->start) {
+            if (parent::valid()) {
+                $this->index += 1;
+                parent::next();
+            } else {
+                return false;
+            }
         }
-        return parent::valid();
+
+        if (null === $this->end || $this->index < $this->end) {
+            return parent::valid();
+        }
+
+        return false;
     }
 
     public function next()

--- a/tests/Zicht/ItertoolsTest/CountTest.php
+++ b/tests/Zicht/ItertoolsTest/CountTest.php
@@ -14,14 +14,47 @@ class CountTest extends PHPUnit_Framework_TestCase
     {
         $iterator = \Zicht\Itertools\count($start, $step);
         $this->assertInstanceOf('\Zicht\Itertools\lib\CountIterator', $iterator);
-        $iterator->rewind();
-
         $this->assertEquals(sizeof($expectedKeys), sizeof($expectedValues));
-        for ($index=0; $index<sizeof($expectedKeys); $index++) {
-            $this->assertTrue($iterator->valid(), 'Failure in $iterator->valid()');
-            $this->assertEquals($expectedKeys[$index], $iterator->key(), 'Failure in $iterator->key()');
-            $this->assertEquals($expectedValues[$index], $iterator->current(), 'Failure in $iterator->current()');
-            $iterator->next();
+
+        for ($rewindCounter=0; $rewindCounter<2; $rewindCounter++) {
+            $iterator->rewind();
+
+            for ($index=0; $index<sizeof($expectedKeys); $index++) {
+                $this->assertTrue($iterator->valid(), 'Failure in $iterator->valid()');
+                $this->assertEquals($expectedKeys[$index], $iterator->key(), 'Failure in $iterator->key()');
+                $this->assertEquals($expectedValues[$index], $iterator->current(), 'Failure in $iterator->current()');
+                $iterator->next();
+            }
+        }
+    }
+
+    /**
+     * Use foreach to iterate
+     *
+     * Using foreach or valid(), next(), etc, should always result in the same behavior
+     *
+     * @dataProvider goodSequenceProvider
+     */
+    public function testGoodSequence_foreach($start, $step, array $expectedKeys, array $expectedValues)
+    {
+        $iterator = \Zicht\Itertools\count($start, $step);
+        $this->assertInstanceOf('\Zicht\Itertools\lib\CountIterator', $iterator);
+        $this->assertEquals(sizeof($expectedKeys), sizeof($expectedValues));
+
+        for ($rewindCounter=0; $rewindCounter<2; $rewindCounter++) {
+            $index = 0;
+            foreach ($iterator as $key => $value) {
+                if (sizeof($expectedValues) <= $index) {
+                    break;
+                }
+
+                $this->assertEquals($expectedKeys[$index], $key, 'Failure in $key');
+                $this->assertEquals($expectedValues[$index], $value, 'Failure in $value');
+                $this->assertTrue($iterator->valid(), 'Failure in $iterator->valid()');
+
+                $index++;
+            }
+            $this->assertEquals(sizeof($expectedValues), $index);
         }
     }
 

--- a/tests/Zicht/ItertoolsTest/SliceTest.php
+++ b/tests/Zicht/ItertoolsTest/SliceTest.php
@@ -8,26 +8,84 @@ use PHPUnit_Framework_TestCase;
 class SliceTest extends PHPUnit_Framework_TestCase
 {
     /**
+     * Test using the infinite count iterable
+     */
+    public function testCombinedWithCountStartingAtZero()
+    {
+        // [0, 1, 2, 3, ...][0:3] -> [0, 1, 2]
+        $iterator = \Zicht\Itertools\count(0)->slice(0, 3);
+        $this->assertEquals(3, sizeof($iterator));
+
+        $iterator->rewind();
+        $this->assertTrue($iterator->valid(), 'Failure in $iterator->valid()');
+        $this->assertEquals(0, $iterator->key(), 'Failure in $iterator->key()');
+        $this->assertEquals(0, $iterator->current(), 'Failure in $iterator->current()');
+
+        $iterator->next();
+        $this->assertTrue($iterator->valid(), 'Failure in $iterator->valid()');
+        $this->assertEquals(1, $iterator->key(), 'Failure in $iterator->key()');
+        $this->assertEquals(1, $iterator->current(), 'Failure in $iterator->current()');
+
+        $iterator->next();
+        $this->assertTrue($iterator->valid(), 'Failure in $iterator->valid()');
+        $this->assertEquals(2, $iterator->key(), 'Failure in $iterator->key()');
+        $this->assertEquals(2, $iterator->current(), 'Failure in $iterator->current()');
+
+        $iterator->next();
+        $this->assertFalse($iterator->valid(), 'Failure in $iterator->valid()');
+    }
+
+    /**
+     * Test using the infinite count iterable
+     */
+    public function testCombinedWithCountStartingAtNonZero()
+    {
+        // [0, 1, 2, 3, ...][2:5] -> [2, 3, 4]
+        $iterator = \Zicht\Itertools\count(0)->slice(2, 5);
+        $this->assertEquals(3, sizeof($iterator));
+
+        $iterator->rewind();
+        $this->assertTrue($iterator->valid(), 'Failure in $iterator->valid()');
+        $this->assertEquals(2, $iterator->key(), 'Failure in $iterator->key()');
+        $this->assertEquals(2, $iterator->current(), 'Failure in $iterator->current()');
+
+        $iterator->next();
+        $this->assertTrue($iterator->valid(), 'Failure in $iterator->valid()');
+        $this->assertEquals(3, $iterator->key(), 'Failure in $iterator->key()');
+        $this->assertEquals(3, $iterator->current(), 'Failure in $iterator->current()');
+
+        $iterator->next();
+        $this->assertTrue($iterator->valid(), 'Failure in $iterator->valid()');
+        $this->assertEquals(4, $iterator->key(), 'Failure in $iterator->key()');
+        $this->assertEquals(4, $iterator->current(), 'Failure in $iterator->current()');
+
+        $iterator->next();
+        $this->assertFalse($iterator->valid(), 'Failure in $iterator->valid()');
+    }
+
+    /**
      * @dataProvider goodSequenceProvider
      */
     public function testGoodSequence(array $arguments, array $expectedKeys, array $expectedValues)
     {
         $iterator = call_user_func_array('\Zicht\Itertools\slice', $arguments);
         $this->assertInstanceOf('\Zicht\Itertools\lib\SliceIterator', $iterator);
-        $this->assertEquals(sizeof($expectedKeys), sizeof($expectedValues));
-        $this->assertEquals(sizeof($iterator), sizeof($expectedKeys));
-        $this->assertEquals(iterator_count($iterator), sizeof($expectedKeys));
-        $iterator->rewind();
+        $this->assertEquals(sizeof($expectedKeys), sizeof($expectedValues), 'Failure in expected input length');
+        $this->assertEquals(sizeof($expectedKeys), sizeof($iterator), 'Failure in input length (a)');
+        $this->assertEquals(sizeof($expectedKeys), iterator_count($iterator), 'Failure in input length (b)');
 
-        $this->assertEquals(sizeof($expectedKeys), sizeof($expectedValues));
-        for ($index=0; $index<sizeof($expectedKeys); $index++) {
-            $this->assertTrue($iterator->valid(), 'Failure in $iterator->valid()');
-            $this->assertEquals($expectedKeys[$index], $iterator->key(), 'Failure in $iterator->key()');
-            $this->assertEquals($expectedValues[$index], $iterator->current(), 'Failure in $iterator->current()');
-            $iterator->next();
+        for ($rewindCounter=0; $rewindCounter<2; $rewindCounter++) {
+            $iterator->rewind();
+
+            for ($index=0; $index<sizeof($expectedKeys); $index++) {
+                $this->assertTrue($iterator->valid(), 'Failure in $iterator->valid()');
+                $this->assertEquals($expectedKeys[$index], $iterator->key(), 'Failure in $iterator->key()');
+                $this->assertEquals($expectedValues[$index], $iterator->current(), 'Failure in $iterator->current()');
+                $iterator->next();
+            }
+
+            $this->assertFalse($iterator->valid(), 'Failure in $iterator->valid()');
         }
-
-        $this->assertFalse($iterator->valid());
     }
 
     /**


### PR DESCRIPTION
Discovered this when using the count iterator (which is infinite) in combination with the slice iterator.