### PR TITLE
Made reductions\chain behavior stateless

### DIFF
--- a/src/Zicht/Itertools/reductions.php
+++ b/src/Zicht/Itertools/reductions.php
@@ -124,20 +124,16 @@ function join($glue = '')
  * Returns a closure that chains lists together
  *
  * > $lists = [[1, 2, 3], [4, 5, 6]]
- * > iterable($lists)->reduce(reductions\chain())
+ * > iterable($lists)->reduce(reductions\chain(), new ChainIterator())
  * results in a ChainIterator: 1, 2, 3, 4, 5, 6
  *
  * @return \Closure
  */
 function chain()
 {
-    $chainIterator = new ChainIterator();
-    $isFirst = true;
-
-    return function ($a, $b) use ($chainIterator, &$isFirst) {
-        if ($isFirst) {
-            $isFirst = false;
-            $chainIterator->extend($a);
+    return function ($chainIterator, $b) {
+        if (!($chainIterator instanceof ChainIterator)) {
+            throw new \InvalidArgumentException('Argument $A must be a ChainIterator.  Did your call "reduce" with "new ChainIterator()" as the initial parameter?');
         }
 
         $chainIterator->extend($b);

--- a/tests/Zicht/ItertoolsTest/reductions/ChainTest.php
+++ b/tests/Zicht/ItertoolsTest/reductions/ChainTest.php
@@ -23,10 +23,34 @@ class ChainTest extends PHPUnit_Framework_TestCase
     public function test()
     {
         $lists = [['a' => 1, 'b' => 2, 'c' => 3], ['d' => 4, 'e' => 5, 'f' => 6], ['g' => 7, 'h' => 8, 'i' => 9]];
-        $result = iter\iterable($lists)->reduce(reductions\chain());
+        $result = iter\iterable($lists)->reduce(reductions\chain(), new iter\lib\ChainIterator());
         $this->assertInstanceOf(iter\lib\ChainIterator::class, $result);
         $this->assertEquals(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'], $result->keys());
         $this->assertEquals([1, 2, 3, 4, 5, 6, 7, 8, 9], $result->values());
+    }
+
+    /**
+     * Test empty
+     */
+    public function testEmpty()
+    {
+        $lists = [];
+        $result = iter\iterable($lists)->reduce(reductions\chain(), new iter\lib\ChainIterator());
+        $this->assertInstanceOf(iter\lib\ChainIterator::class, $result);
+        $this->assertEquals([], $result->keys());
+        $this->assertEquals([], $result->values());
+    }
+
+    /**
+     * The $initializer must be a ChainIterator
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInitializerChainIterator()
+    {
+        $result = iter\iterable([[1, 2, 3], [4, 5, 6]])->reduce(reductions\chain());
+        $this->assertInstanceOf(iter\lib\ChainIterator::class, $result);
+        $result->values();
     }
 
     /**
@@ -42,7 +66,7 @@ class ChainTest extends PHPUnit_Framework_TestCase
     {
         $closure = call_user_func_array('\Zicht\Itertools\reductions\get_reduction', $arguments);
         $this->assertInstanceOf('\Closure', $closure);
-        $this->assertEquals($expected, iter\iterable($data)->reduce($closure)->values());
+        $this->assertEquals($expected, iter\iterable($data)->reduce($closure, new iter\lib\ChainIterator())->values());
     }
 
     /**
@@ -58,7 +82,7 @@ class ChainTest extends PHPUnit_Framework_TestCase
     {
         $closure = call_user_func_array('\Zicht\Itertools\reductions\getReduction', $arguments);
         $this->assertInstanceOf('\Closure', $closure);
-        $this->assertEquals($expected, iter\iterable($data)->reduce($closure)->values());
+        $this->assertEquals($expected, iter\iterable($data)->reduce($closure, new iter\lib\ChainIterator())->values());
     }
 
     /**


### PR DESCRIPTION
Before reductions\chain is released, I feel this change is needed to
ensure that the reduction is stateless.

This also fixes cases where the data list that is being iterated over
is only a single element long.  This would result in that single
element being returned (as per reduce behavior).  While we expect a
ChainIterator as the reduce result.