### PR TITLE
Replace deprecated markdown format for tables in upgrade doc

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -34,15 +34,15 @@ $myIterable->reduce(Reductions::add());
 
 #### Migrations:
 ```markdown
-Old      | New
--------- | -------------------
-add()    | Reductions::add()
-chain()  | Reductions::chain()
-join()   | Reductions::join()
-max()    | Reductions::max()
-min()    | Reductions::min()
-mul()    | Reductions::mul()
-sub()    | Reductions::sub()
+| Old     | New                 |
+|---------|---------------------|
+| add()   | Reductions::add()   |
+| chain() | Reductions::chain() |
+| join()  | Reductions::join()  |
+| max()   | Reductions::max()   |
+| min()   | Reductions::min()   |
+| mul()   | Reductions::mul()   |
+| sub()   | Reductions::sub()   |
 ```
 
 
@@ -65,23 +65,23 @@ iterable($example)->map(Mappings::length());
 
 #### Migrations:
 ```markdown
-Old             | New
---------------- | ----------------------
-cache()         | Mappings::cache()
-constant()      | Mappings::constant()
-json_decode()   | Mappings::jsonEncode()
-json_encode()   | Mappings::jsonDecode()
-key()           | Mappings::key()
-length()        | Mappings::length()
-lower()         | Mappings::lower()
-lstrip()        | Mappings::lstrip()
-random()        | Mappings::random()
-rstrip()        | Mappings::rstrip()
-select()        | Mappings::select()
-string()        | Mappings::string()
-strip()         | Mappings::strip()
-type()          | Mappings::type()
-upper()         | Mappings::upper()
+| Old           | New                    |
+|---------------|------------------------|
+| cache()       | Mappings::cache()      |
+| constant()    | Mappings::constant()   |
+| json_decode() | Mappings::jsonEncode() |
+| json_encode() | Mappings::jsonDecode() |
+| key()         | Mappings::key()        |
+| length()      | Mappings::length()     |
+| lower()       | Mappings::lower()      |
+| lstrip()      | Mappings::lstrip()     |
+| random()      | Mappings::random()     |
+| rstrip()      | Mappings::rstrip()     |
+| select()      | Mappings::select()     |
+| string()      | Mappings::string()     |
+| strip()       | Mappings::strip()      |
+| type()        | Mappings::type()       |
+| upper()       | Mappings::upper()      |
 ```
 
 
@@ -102,16 +102,16 @@ Filters::not($strategy);
 
 #### Migrations:
 ```markdown
-Old       | New
---------- | -------------------
-after()   | Filters::after()
-before()  | Filters::before()
-equals()  | Filters::equals()
-in()      | Filters::in()
-match()   | Filters::match()
-not()     | Filters::not()
-not_in()  | Filters::not(Filters::in())
-type()    | Filters::type()
+| Old      | New                         |
+|----------|-----------------------------|
+| after()  | Filters::after()            |
+| before() | Filters::before()           |
+| equals() | Filters::equals()           |
+| in()     | Filters::in()               |
+| match()  | Filters::match()            |
+| not()    | Filters::not()              |
+| not_in() | Filters::not(Filters::in()) |
+| type()   | Filters::type()             |
 ```
 
 
@@ -130,30 +130,30 @@ becomes:
 
 #### Migrations:
 ```markdown
-Old        | New
----------- | ----------
-all        | it.all
-any        | it.any
-chain      | it.chain
-collapse   | it.collapse
-filter     | it.filter
-filterby   | it.filter
-first      | it.first
-groupby    | it.groupBy
-groupBy    | it.groupBy
-group_by   | it.groupBy
-last       | it.last
-map        | it.map
-mapby      | it.mapBy
-mapBy      | it.mapBy
-map_by     | it.mapBy
-reduce     | it.reduce
-reversed   | it.reversed
-sorted     | it.sorted
-sum        | it.reduce
-unique     | it.unique
-uniqueby   | it.unique
-zip        | it.zip
+| Old      | New         |
+|----------|-------------|
+| all      | it.all      |
+| any      | it.any      |
+| chain    | it.chain    |
+| collapse | it.collapse |
+| filter   | it.filter   |
+| filterby | it.filter   |
+| first    | it.first    |
+| groupby  | it.groupBy  |
+| groupBy  | it.groupBy  |
+| group_by | it.groupBy  |
+| last     | it.last     |
+| map      | it.map      |
+| mapby    | it.mapBy    |
+| mapBy    | it.mapBy    |
+| map_by   | it.mapBy    |
+| reduce   | it.reduce   |
+| reversed | it.reversed |
+| sorted   | it.sorted   |
+| sum      | it.reduce   |
+| unique   | it.unique   |
+| uniqueby | it.unique   |
+| zip      | it.zip      |
 ```
 
 
@@ -170,12 +170,12 @@ becomes:
 
 #### Migrations:
 ```markdown
-Old        | New
----------- | ----------
-chain      | it.chain
-first      | it.first
-last       | it.last
-reducing   | itr
-mapping    | itm
-filtering  | itf
+| Old       | New      |
+|-----------|----------|
+| chain     | it.chain |
+| first     | it.first |
+| last      | it.last  |
+| reducing  | itr      |
+| mapping   | itm      |
+| filtering | itf      |
 ```


### PR DESCRIPTION
PhpStorm said 'no' against the previous table markdown formatting :smile_cat: 